### PR TITLE
docs: Add CI tested examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,7 @@ name: Tests
 on: [ push, pull_request ]
 
 jobs:
-  pytest:
-    name: python
+  tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +15,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run pytest
-        run: uv run pytest --cov-report=xml:coverage.xml --cov icland
+        run: uv run pytest --cov-report=xml:coverage.xml --doctest-modules --cov icland
 
       - name: Run mypy
         run: uv run mypy --strict .

--- a/src/icland/__init__.py
+++ b/src/icland/__init__.py
@@ -81,10 +81,19 @@ TEST_XML_STRING: str = """
 def sample(key: jax.Array) -> ICLandParams:
     """Sample a new set of environment parameters using 'key'.
 
-    Returns a tuple containing:
-    - mj_model: Mujoco model of the environment.
-    - game: Game string (placeholder, currently None).
-    - agent_count: Number of agents in the environment.
+    Returns:
+        ICLandParams: Parameters for the ICLand environment.
+
+        - mj_model: Mujoco model of the environment.
+        - game: Game string (placeholder, currently None).
+        - agent_count: Number of agents in the environment.
+
+    Examples:
+        >>> from icland import sample
+        >>> import jax
+        >>> key = jax.random.key(42)
+        >>> sample(key)
+        ICLandParams(model=MjModel, game=None, agent_count=1)
     """
     mj_model: mujoco.MjModel = mujoco.MjModel.from_xml_string(TEST_XML_STRING)
     return ICLandParams(mj_model, None, 1)
@@ -93,10 +102,20 @@ def sample(key: jax.Array) -> ICLandParams:
 def init(key: jax.Array, params: ICLandParams) -> ICLandState:
     """Initialize the environment state from params.
 
-    Returns a tuple containing:
-    - mjx_model: JAX-compatible Mujoco model.
-    - mjx_data: JAX-compatible Mujoco data.
-    - object_ids: Array of body and geometry IDs for agents.
+    Returns:
+        ICLandState: State of the ICLand environment.
+
+        - mjx_model: JAX-compatible Mujoco model.
+        - mjx_data: JAX-compatible Mujoco data.
+        - agent_data: Body and geometry IDs for agents.
+
+    Examples:
+        >>> from icland import sample, init
+        >>> import jax
+        >>> key = jax.random.key(42)
+        >>> params = sample(key)
+        >>> init(key, params)
+        ICLandState(mjx_model=Model(...), mjx_data=Data(...), agent_data=AgentData(...))
     """
     mj_model = params.model
     agent_count = params.agent_count
@@ -135,10 +154,23 @@ def step(
 ) -> ICLandState:
     """Advance environment one step for all agents.
 
-    Returns the updated state containing:
-    - mjx_model: Updated Mujoco model.
-    - mjx_data: Updated Mujoco data.
-    - agent_data: Body and geometry IDs for agents.
+    Returns:
+        ICLandState: State of the ICLand environment.
+
+        - mjx_model: JAX-compatible Mujoco model.
+        - mjx_data: JAX-compatible Mujoco data.
+        - agent_data: Body and geometry IDs for agents.
+
+    Examples:
+        >>> from icland import sample, init, step
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>> forward_policy = jnp.array([1, 0, 0])
+        >>> key = jax.random.key(42)
+        >>> params = sample(key)
+        >>> state = init(key, params)
+        >>> step(key, state, params, forward_policy)
+        ICLandState(mjx_model=Model(...), mjx_data=Data(...), agent_data=AgentData(...))
     """
     mjx_model = state.mjx_model
     mjx_data = state.mjx_data

--- a/src/icland/types.py
+++ b/src/icland/types.py
@@ -30,6 +30,13 @@ class ICLandParams(PyTreeNode):  # type: ignore[misc]
     game: Optional[str]
     agent_count: int
 
+    # Without this, model is model=<mujoco._structs.MjModel object at 0x7b61fb18dc70>
+    # For some arbitrary memory address. __repr__ provides cleaner output
+    # for users and for testing.
+    def __repr__(self) -> str:
+        """Return a string representation of the ICLandParams object."""
+        return f"ICLandParams(model={type(self.model).__name__}, game={self.game}, agent_count={self.agent_count})"
+
 
 class AgentData(PyTreeNode):  # type: ignore[misc]
     r"""\Agent in the ICLand environment.

--- a/tests/video_generator.py
+++ b/tests/video_generator.py
@@ -109,10 +109,11 @@ def render_video(
     imageio.mimsave(video_name, third_person_frames, fps=30, quality=8)
 
 
-for i, preset in enumerate(SIMULATION_PRESETS):
-    render_video(
-        preset["world"],
-        preset["policy"],
-        preset["duration"],
-        f"tests/output/video_{preset['name']}.mp4",
-    )
+if __name__ == "__main__":
+    for i, preset in enumerate(SIMULATION_PRESETS):
+        render_video(
+            preset["world"],
+            preset["policy"],
+            preset["duration"],
+            f"tests/output/video_{preset['name']}.mp4",
+        )


### PR DESCRIPTION
Fleshes out `__init__.py` docstrings with examples that are tested as part of CI. Also, I wrapped the video generation so that videos aren't generated when we import from the file (compared to running it directly).

This PR is a small step towards our API documentation:

<img width="797" alt="image" src="https://github.com/user-attachments/assets/6efeddc8-a4d7-441a-9d92-515cadf56dd5" />