### PR TITLE
refactor: add missing types for brax + benchmarking

### DIFF
--- a/benchmarking/sys_info.py
+++ b/benchmarking/sys_info.py
@@ -6,14 +6,13 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import Dict, Union  # For type annotations
 
 import cpuinfo
 import GPUtil
 import psutil
 
 
-def get_cpu_info() -> Dict[str, str]:
+def get_cpu_info() -> dict[str, str]:
     """Get CPU information."""
     info = cpuinfo.get_cpu_info()
     return {
@@ -26,7 +25,7 @@ def get_cpu_info() -> Dict[str, str]:
     }
 
 
-def get_memory_info() -> Dict[str, str]:
+def get_memory_info() -> dict[str, str]:
     """Get memory information."""
     mem = psutil.virtual_memory()
     return {
@@ -35,7 +34,7 @@ def get_memory_info() -> Dict[str, str]:
     }
 
 
-def get_storage_info() -> Dict[str, str]:
+def get_storage_info() -> dict[str, str]:
     """Get storage information."""
     disk = shutil.disk_usage("/")
     return {
@@ -48,7 +47,7 @@ def get_storage_info() -> Dict[str, str]:
     }
 
 
-def get_os_info() -> Dict[str, str]:
+def get_os_info() -> dict[str, str]:
     """Get OS information."""
     return {
         "OS": platform.system(),
@@ -59,7 +58,7 @@ def get_os_info() -> Dict[str, str]:
     }
 
 
-def get_python_info() -> Dict[str, str]:
+def get_python_info() -> dict[str, str]:
     """Get Python information."""
     return {
         "Python Version": sys.version,
@@ -70,11 +69,11 @@ def get_python_info() -> Dict[str, str]:
     }
 
 
-def get_gpu_info() -> Dict[str, Union[str, Dict[str, str]]]:
+def get_gpu_info() -> dict[str, dict[str, str]]:
     """Get GPU information."""
     gpus = GPUtil.getGPUs()
     if not gpus:
-        return {"GPU": "No dedicated GPU found"}
+        return {"GPU": {"Model": "No dedicated GPU found"}}
     return {
         f"GPU {i + 1}": {
             "Model": gpu.name,

--- a/src/icland/brax_env.py
+++ b/src/icland/brax_env.py
@@ -14,7 +14,7 @@ from flax import struct
 
 import icland
 from icland.constants import AGENT_OBSERVATION_DIM
-from icland.types import ICLandState
+from icland.types import ICLandState, MjxModelType, MjxStateType
 
 
 @struct.dataclass
@@ -26,8 +26,8 @@ class ICLandBraxState(base.Base):  # type: ignore
     obs: Observation
     reward: jax.Array
     done: jax.Array
-    metrics: Dict[str, jax.Array] = struct.field(default_factory=dict)  # type: ignore
-    info: Dict[str, Any] = struct.field(default_factory=dict)  # type: ignore
+    metrics: Dict[str, jax.Array] = struct.field(default_factory=dict)  # type: ignore[no-untyped-call]
+    info: Dict[str, Any] = struct.field(default_factory=dict)  # type: ignore[no-untyped-call]
 
 
 class ICLand(Env):  # type: ignore
@@ -109,7 +109,9 @@ class ICLand(Env):  # type: ignore
 
         return nstate
 
-    def _build_pipeline_state(self, model, data) -> base.State:  # type: ignore
+    def _build_pipeline_state(
+        self, model: MjxModelType, data: MjxStateType
+    ) -> base.State:
         """Helper method to create a pipeline state from the provided model and data.
 
         Args:


### PR DESCRIPTION
Removed `# type: ignore` from the top of benchmarking files and added correct type hints.

Reduced `Any` types in Brax code.