### PR TITLE
fix: Ensure type safety for jitted functions at runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run pytest
-        run: uv run pytest --cov-report=xml:coverage.xml --doctest-modules --cov icland
+        run: uv run pytest --cov-report=xml:coverage.xml --doctest-modules --cov icland src tests
 
       - name: Run mypy
         run: uv run mypy --strict .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = []
 requires-python = ">=3.13"
 dependencies = [
+    "beartype>=0.19.0",
     "brax>=0.12.1",
     "flax>=0.10.2",
     "gputil>=1.4.0",
@@ -13,6 +14,7 @@ dependencies = [
     "imageio[ffmpeg]>=2.37.0",
     "jax>=0.5.0 ; sys_platform != 'linux'",
     "jax[cuda12]>=0.5.0 ; sys_platform == 'linux'",
+    "jaxtyping>=0.2.37",
     "keyboard>=0.13.5",
     "matplotlib>=3.10.0",
     "mujoco>=3.2.6",

--- a/src/icland/__init__.py
+++ b/src/icland/__init__.py
@@ -1,5 +1,11 @@
 """Recreating Google DeepMind's XLand RL environment in JAX."""
 
+from beartype.claw import beartype_this_package
+
+# Enforce runtime type-checking.
+# See: https://beartype.readthedocs.io/en/latest/api_claw/
+beartype_this_package()
+
 import jax
 import jax.numpy as jnp
 import mujoco

--- a/src/icland/agent.py
+++ b/src/icland/agent.py
@@ -9,6 +9,8 @@ import mujoco
 from .constants import *
 from .types import *
 
+AGENT_HEIGHT = 0.4
+
 
 def create_agent(
     id: int, pos: jax.Array, specification: mujoco.MjSpec
@@ -42,7 +44,7 @@ def create_agent(
         name=f"agent{id}_geom",
         type=mujoco.mjtGeom.mjGEOM_CAPSULE,
         size=[0.06, 0.06, 0.06],
-        fromto=[0, 0, 0, 0, 0, -0.4],
+        fromto=[0, 0, 0, 0, 0, -AGENT_HEIGHT],
         mass=1,
     )
 

--- a/src/icland/agent.py
+++ b/src/icland/agent.py
@@ -254,7 +254,14 @@ def collect_body_scene_info(
     ]  # Adjusting index for rotation extraction.
 
     return ICLandInfo(
-        agent_positions=positions,
-        agent_rotations=rotations,
-        agent_velocities=velocities,
+        agents=[
+            Agent(position=positions[i], velocity=velocities[i], rotation=rotations[i])
+            for i in range(len(body_ids))
+        ]
     )
+
+    # return ICLandInfo(
+    #     agent_positions=positions,
+    #     agent_rotations=rotations,
+    #     agent_velocities=velocities,
+    # )

--- a/src/icland/game.py
+++ b/src/icland/game.py
@@ -49,7 +49,8 @@ def generate_game(
         def reward_function(info: ICLandInfo) -> jax.Array:
             """Compute reward based on agent position relative to a target position."""
             # Extract the first two coordinates (x, y) of agent positions.
-            agent_positions = info.agent_positions[:, :2]
+            # agent_positions = info.agent_positions[:, :2]
+            agent_positions = jnp.array([agent.position[:2] for agent in info.agents])
             # Compute Euclidean distance from each agent to its target.
             distance = jnp.linalg.norm(agent_positions - target_position, axis=1)
             # Reward is 1 if the distance is less than the acceptable threshold.
@@ -67,7 +68,8 @@ def generate_game(
         def reward_function(info: ICLandInfo) -> jax.Array:
             """Compute reward based on agent rotation relative to a target rotation."""
             # Extract the agent rotations.
-            agent_rotation = info.agent_rotations
+            # agent_rotation = info.agent_rotations
+            agent_rotation = jnp.array([agent.rotation for agent in info.agents])
             # Compute the absolute difference between agent rotation and target.
             distance = jnp.abs(agent_rotation - target_rotation)
             # Reward is 1 if the rotation difference is within the acceptable threshold.

--- a/src/icland/game.py
+++ b/src/icland/game.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import PRNGKeyArray
 
 from .constants import *
 from .types import *
@@ -13,7 +14,7 @@ ACCEPTABLE_DISTANCE = 0.5
 
 
 def generate_game(
-    key: jax.Array, agent_count: int
+    key: PRNGKeyArray, agent_count: int
 ) -> Callable[[ICLandInfo], jax.Array]:
     """Generate a game using the given random key and agent count.
 

--- a/src/icland/types.py
+++ b/src/icland/types.py
@@ -3,6 +3,7 @@
 It includes types for model parameters, state, and action sets used in the project.
 """
 
+import dataclasses
 import inspect
 from collections.abc import Callable
 from typing import TypeAlias
@@ -10,6 +11,7 @@ from typing import TypeAlias
 import jax
 import jax.numpy as jnp
 import mujoco
+from jaxtyping import Array, Float
 from mujoco.mjx._src.dataclasses import PyTreeNode
 
 """Type variables from external modules."""
@@ -43,9 +45,15 @@ class PipelineState(PyTreeNode):  # type: ignore[misc]
 class Agent(PyTreeNode):  # type: ignore[misc]
     """Information about an agent in the ICLand environment."""
 
-    position: jax.Array
-    velocity: jax.Array
-    rotation: jax.Array
+    position: Float[Array, "3"]
+    velocity: Float[Array, "4"]
+    rotation: Float[Array, "1"] | Float[Array, ""]
+
+
+class Prop(PyTreeNode):  # type: ignore[misc]
+    """Information about a prop in the ICLand environment."""
+
+    centre_of_mass: Float[Array, "3"]
 
 
 class ICLandInfo(PyTreeNode):  # type: ignore[misc]
@@ -58,6 +66,8 @@ class ICLandInfo(PyTreeNode):  # type: ignore[misc]
     """
 
     agents: list[Agent]
+    # TODO: Initialise values of props
+    props: list[Prop] = dataclasses.field(default_factory=list)
 
 
 class ICLandState(PyTreeNode):  # type: ignore[misc]

--- a/src/icland/types.py
+++ b/src/icland/types.py
@@ -40,6 +40,14 @@ class PipelineState(PyTreeNode):  # type: ignore[misc]
         return f"PipelineState(mjx_model={type(self.mjx_model).__name__}, mjx_data={type(self.mjx_data).__name__}, component_ids={self.component_ids})"
 
 
+class Agent(PyTreeNode):  # type: ignore[misc]
+    """Information about an agent in the ICLand environment."""
+
+    position: jax.Array
+    velocity: jax.Array
+    rotation: jax.Array
+
+
 class ICLandInfo(PyTreeNode):  # type: ignore[misc]
     """Information about the ICLand environment.
 
@@ -49,9 +57,7 @@ class ICLandInfo(PyTreeNode):  # type: ignore[misc]
         agent_rotations: Quat of agent rotations, indexed by agent's body ID.
     """
 
-    agent_positions: jax.Array
-    agent_velocities: jax.Array
-    agent_rotations: jax.Array
+    agents: list[Agent]
 
 
 class ICLandState(PyTreeNode):  # type: ignore[misc]

--- a/src/icland/world_gen/JITModel.py
+++ b/src/icland/world_gen/JITModel.py
@@ -7,13 +7,14 @@ from typing import TypedDict, cast
 import jax
 import jax.numpy as jnp
 from flax import struct
+from jaxtyping import Array, Bool, Float, Int
 
 from icland.world_gen.tile_data import NUM_ACTIONS, PROPAGATOR, TILECODES, WEIGHTS
 
 
 @jax.jit
 def _random_index_from_distribution(
-    distribution: jax.Array, rand_value: jax.Array
+    distribution: jax.Array, rand_value: Float[Array, "1"] | Float[Array, ""] | float
 ) -> jax.Array:
     """Select an index from 'distribution' proportionally to the values in 'distribution'.
 
@@ -63,19 +64,19 @@ class JITModel(struct.PyTreeNode):  # type: ignore[no-untyped-call]
     """Base Model class for WaveFunctionCollapse algorithm."""
 
     # Basic config
-    MX: jnp.int32
-    MY: jnp.int32
-    periodic: bool
-    heuristic: jnp.int32
+    MX: int | Int[Array, ""]
+    MY: int | Int[Array, ""]
+    periodic: bool | Bool[Array, ""]
+    heuristic: int | Int[Array, ""]
 
     # number of possible tile/pattern indices
-    T: jnp.int32
+    T: int | Int[Array, ""]
     # Sample size (N=1 for simple tiles)
-    N: jnp.int32
+    N: int | Int[Array, ""]
 
     # Core arrays
     # how many elements in the stack are currently valid
-    stacksize: jnp.int32
+    stacksize: int | Int[Array, ""]
     wave: jax.Array  # shape: (MX*MY, T), dtype=bool
     compatible: jax.Array  # shape: (MX*MY, T, 4), dtype=int
     observed: jax.Array  # shape: (MX*MY, ), dtype=int
@@ -92,12 +93,12 @@ class JITModel(struct.PyTreeNode):  # type: ignore[no-untyped-call]
     entropies: jax.Array  # shape: (MX*MY,)
 
     # Precomputed sums for the entire set of patterns
-    sum_of_weights: jnp.float32
-    sum_of_weight_log_weights: jnp.float32
-    starting_entropy: jnp.float32
+    sum_of_weights: Float[Array, ""]
+    sum_of_weight_log_weights: Float[Array, ""]
+    starting_entropy: Float[Array, ""]
 
     # Because SCANLINE uses an incremental pointer
-    observed_so_far: jnp.int32
+    observed_so_far: int | Int[Array, ""]
 
     propagator: jax.Array  # (4, T, propagator_length)
     distribution: jax.Array  # shape: (T, )
@@ -107,12 +108,12 @@ class JITModel(struct.PyTreeNode):  # type: ignore[no-untyped-call]
 
 @partial(jax.jit, static_argnums=[0, 1, 2])
 def _init(
-    width: jnp.int32,
-    height: jnp.int32,
-    T: jnp.int32,
-    N: jnp.int32,
+    width: int,
+    height: int,
+    T: int,
+    N: int,
     periodic: bool,
-    heuristic: jnp.int32,
+    heuristic: int,
     weights: jax.Array,
     propagator: jax.Array,
     key: jax.Array,
@@ -178,7 +179,7 @@ def _init(
 
 
 @jax.jit
-def _observe(model: JITModel, node: jax.Array) -> JITModel:
+def _observe(model: JITModel, node: Int[Array, ""]) -> JITModel:
     """Collapses the wave at 'node' by picking a pattern index according to weights distribution.
 
     Then bans all other patterns at that node.
@@ -205,7 +206,7 @@ def _observe(model: JITModel, node: jax.Array) -> JITModel:
 
 
 @jax.jit
-def _ban(model: JITModel, i: jax.Array, t1: jax.Array) -> JITModel:
+def _ban(model: JITModel, i: Int[Array, ""], t1: jax.Array) -> JITModel:
     """Bans pattern t at cell i. Updates wave, compatibility, sums_of_ones, entropies, and stack."""
     t = jnp.int32(t1)
     condition_1 = jnp.logical_not(model.wave.at[i, t].get())
@@ -261,18 +262,23 @@ class RunState(TypedDict):
     model: JITModel
     steps: int
     done: bool
-    success: bool
+    success: Bool[Array, ""]
 
 
 def _run(
     model: JITModel, max_steps: jax.Array = jnp.array(1000, dtype=jnp.int32)
-) -> tuple[JITModel, bool]:
+) -> tuple[JITModel, Bool[Array, ""]]:
     """Run the WaveFunctionCollapse algorithm with the given seed and iteration limit."""
     # Pre: the model is freshly initialized
 
     model = _clear(model)
     # Define the loop state
-    init_state: RunState = {"model": model, "steps": 0, "done": False, "success": True}
+    init_state: RunState = {
+        "model": model,
+        "steps": 0,
+        "done": False,
+        "success": jnp.array(True, dtype=bool),
+    }
 
     def cond_fun(state: RunState) -> jax.Array:
         """Condition function for the while loop."""
@@ -341,7 +347,7 @@ def _run(
     final_state = jax.lax.while_loop(cond_fun, body_fun, init_state)
     final_model: JITModel = final_state["model"]
 
-    success: bool = final_state["success"]
+    success = final_state["success"]
 
     return final_model, success
 
@@ -377,7 +383,7 @@ def _next_unobserved_node(model: JITModel) -> tuple[JITModel, jax.Array]:
     all_indices = jnp.arange(model.wave.shape[0])
     valid_nodes_mask = jax.vmap(within_bounds)(all_indices)
 
-    def scanline_heuristic(_: None) -> tuple[JITModel, jax.Array]:
+    def scanline_heuristic(_: jax.Array) -> tuple[JITModel, jax.Array]:
         observed_mask = all_indices >= observed_so_far
         sum_of_ones_mask = model.sums_of_ones[all_indices] > 1
 
@@ -412,7 +418,7 @@ def _next_unobserved_node(model: JITModel) -> tuple[JITModel, jax.Array]:
             ),
         )
 
-    def entropy_mrv_heuristic(_: None) -> tuple[JITModel, jax.Array]:
+    def entropy_mrv_heuristic(_: jax.Array) -> tuple[JITModel, jax.Array]:
         node_entropies = jax.lax.cond(
             heuristic == Heuristic.ENTROPY.value,
             lambda _: entropies,
@@ -617,11 +623,11 @@ def sample_world(
     success = False
 
     def body_func(state: tuple[JITModel, bool]) -> tuple[JITModel, bool]:
-        model, b = state
+        model, _ = state
         model, b = _run(model)
         key, _ = jax.random.split(model.key)
         model = model.replace(key=key)
-        return (model, b)
+        return (model, bool(b))
 
     return cast(
         tuple[JITModel, jax.Array],

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 
 from icland.game import generate_game
-from icland.types import ICLandInfo
+from icland.types import ICLandInfo, Agent
 
 
 # Define a minimal dummy ICLandInfo type with the attributes used by the reward functions.
@@ -31,9 +31,10 @@ def test_generate_game_runs_without_error() -> None:
     # Create a dummy ICLandInfo input.
     # Both fields are provided even though only one is used depending on mode.
     info = ICLandInfo(
-        agent_positions=jnp.zeros((agent_count, 2)),
-        agent_rotations=jnp.zeros((agent_count, 1)),
-        agent_velocities=jnp.zeros((agent_count, 2)),
+        agents=[
+            Agent(position=jnp.zeros(2), rotation=jnp.zeros(1), velocity=jnp.zeros(2))
+            for _ in range(agent_count)
+        ]
     )
 
     # Call the reward function. We don't check the output here,

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 
 from icland.game import generate_game
-from icland.types import ICLandInfo, Agent
+from icland.types import Agent, ICLandInfo
 
 
 # Define a minimal dummy ICLandInfo type with the attributes used by the reward functions.
@@ -32,7 +32,7 @@ def test_generate_game_runs_without_error() -> None:
     # Both fields are provided even though only one is used depending on mode.
     info = ICLandInfo(
         agents=[
-            Agent(position=jnp.zeros(2), rotation=jnp.zeros(1), velocity=jnp.zeros(2))
+            Agent(position=jnp.zeros(3), rotation=jnp.zeros(1), velocity=jnp.zeros(4))
             for _ in range(agent_count)
         ]
     )

--- a/tests/test_jit_model.py
+++ b/tests/test_jit_model.py
@@ -158,7 +158,7 @@ def test_model_observe(model: JITModel) -> None:
     node = 12
 
     # Run the `observe` function
-    observed_model = _observe(model, node)
+    observed_model = _observe(model, jnp.array(node))
     assert model.key != observed_model.key, (
         "The random key should be updated after observation."
     )
@@ -190,7 +190,7 @@ def test_model_ban(model: JITModel) -> None:
     i = 5
     t = 1  # Pattern index to ban
 
-    updated_model = _ban(model, i, jnp.array(t))
+    updated_model = _ban(model, jnp.array(i), jnp.array(t))
 
     assert not updated_model.wave.at[i, t].get(), (
         f"Pattern {t} at cell {i} should be banned."

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/e1/00515b97afa3993b4a314e4bc168fbde0917fd5845435cb6f16a19770746/beartype-0.19.0.tar.gz", hash = "sha256:de42dfc1ba5c3710fde6c3002e3bd2cad236ed4d2aabe876345ab0b4234a6573", size = 1294480 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/f6db6e4cb2fe2f887dead40b76caa91af4844cb647dd2c7223bb010aa416/beartype-0.19.0-py3-none-any.whl", hash = "sha256:33b2694eda0daf052eb2aff623ed9a8a586703bbf0a90bbc475a83bbf427f699", size = 1039760 },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +434,7 @@ name = "icland"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beartype" },
     { name = "brax" },
     { name = "flax" },
     { name = "gputil" },
@@ -432,6 +442,7 @@ dependencies = [
     { name = "imageio", extra = ["ffmpeg"] },
     { name = "jax" },
     { name = "jax", extra = ["cuda12"], marker = "sys_platform == 'linux'" },
+    { name = "jaxtyping" },
     { name = "keyboard" },
     { name = "matplotlib" },
     { name = "mujoco" },
@@ -457,6 +468,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beartype", specifier = ">=0.19.0" },
     { name = "brax", specifier = ">=0.12.1" },
     { name = "flax", specifier = ">=0.10.2" },
     { name = "gputil", specifier = ">=1.4.0" },
@@ -464,6 +476,7 @@ requires-dist = [
     { name = "imageio", extras = ["ffmpeg"], specifier = ">=2.37.0" },
     { name = "jax", marker = "sys_platform != 'linux'", specifier = ">=0.5.0" },
     { name = "jax", extras = ["cuda12"], marker = "sys_platform == 'linux'", specifier = ">=0.5.0" },
+    { name = "jaxtyping", specifier = ">=0.2.37" },
     { name = "keyboard", specifier = ">=0.13.5" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "mujoco", specifier = ">=3.2.6" },
@@ -642,6 +655,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/af/73f7514ea14d6aba0a851e03afbdd532a7af896577c708c6ce405917ce80/jaxopt-0.8.3.tar.gz", hash = "sha256:4b06dfa6f915a4f3291699606245af6069371a48dc5c92d4c507840d62990646", size = 121236 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/a4/fc292a90a9c51d1b633cdffe2df30c702e1e0b3e0b568c7b81004cac0a06/jaxopt-0.8.3-py3-none-any.whl", hash = "sha256:4be2f82798393682529c9ca5046e5397ac6c8657b8acb6bf275e773b28df15b6", size = 172264 },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.2.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/d1/acd3abf3587487ae131a022328c44068c5ca96e766ed2841c292c2a70ffc/jaxtyping-0.2.37.tar.gz", hash = "sha256:ae8c124abbea61b8c56455fb8b42f1183ab63353572aedfb1de355bb5b40e951", size = 45615 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/7b/623d15216d70e6c1cf149163ee4559e6da23ea0118f8cd7c72fdfb951298/jaxtyping-0.2.37-py3-none-any.whl", hash = "sha256:519f694ce569ba5000a1f8823e742df2d86e6da3956d2218769b6bdc5ad2d23a", size = 56263 },
 ]
 
 [[package]]
@@ -3961,6 +3986,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/ca/f23dcb02e161a9bba141b1c08aa50e8da6ea25e6d780528f1d385a3efe25/virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35", size = 7658028 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779", size = 4282379 },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/a2/e8fc843e14aec55d18572a93c5443cc89a6b7d537b90d804f7b373301d9f/wadler_lindig-0.1.3.tar.gz", hash = "sha256:476fb7015135f714cef8f8eac7c44b164c8b993345e651a9b6f25b7b112440c9", size = 15197 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/3b/5b918a0da0d6920e7f7328cf0ab00df31b905d709f458596304f09096785/wadler_lindig-0.1.3-py3-none-any.whl", hash = "sha256:3018e4e6b115a7ef21c77414a41cbe7e03e83f6b5e25004958e33432a17f3c94", size = 20140 },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes some silent type-related bugs in our jitted functions (e.g. passing in an int when the function expects an int array) whilst improving maintainability.

Checks are now properly enforced as well, helping to prevent this from happening again.