### PR TITLE
Add tagging visuals

### DIFF
--- a/scripts/controller.py
+++ b/scripts/controller.py
@@ -10,6 +10,8 @@ Controls:
     - Hold 'd' to command the agent with RIGHT_POLICY.
     - Hold the left arrow key to command the agent with ANTI_CLOCKWISE_POLICY.
     - Hold the right arrow key to command the agent with CLOCKWISE_POLICY.
+    - Press '1' to attempt to tag an agent in front of you with TAG_POLICY.
+    - Press '2' to attempt to grab a prop in front of you with GRAB_POLICY.
     - Press 'q' to quit the simulation.
 
 This script is based on video_generator but instead of writing a video file, it displays frames in real time.
@@ -175,7 +177,7 @@ def interactive_simulation() -> None:
 
     cv2.destroyWindow(window_name)
     print("Interactive simulation ended.")
-    print(f"Exporting video: {'controller.mp4'} number of frame {len(frames)}")
+    print(f"Exporting video: {'controller.mp4'} with {len(frames)} frames.")
     imageio.mimsave(
         "scripts/video_output/controller.mp4", frames, fps=frame_rate, quality=8
     )
@@ -201,7 +203,7 @@ def sdfr_interactive_simulation() -> None:
     frames: list[Any] = []
 
     controlling = 0
-    while True:
+    while cv2.getWindowProperty(window_name, 0) >= 0:
         # Process any pending OpenCV window events.
         cv2.waitKey(1)
 
@@ -262,7 +264,7 @@ def sdfr_interactive_simulation() -> None:
         frame_bgr = cv2.cvtColor(resized_frame, cv2.COLOR_RGB2BGR)
 
         if len(frames) < icland_state.mjx_data.time * framerate:
-            frames.append(frame_bgr)
+            frames.append(resized_frame)
 
         cv2.imshow(window_name, frame_bgr)
 

--- a/src/icland/__init__.py
+++ b/src/icland/__init__.py
@@ -328,6 +328,7 @@ def step(
         agent_variables,
         prop_info,
         prop_variables,
+        action_batch,
         world,
         mjx_data,
     )

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -57,7 +57,11 @@ def test_generate_colormap() -> None:
 
 def test_render_frame_with_objects() -> None:
     """Test if the render_frame_with_objects can correctly render one frame with props."""
-    players = RenderAgentInfo(jnp.array([[8.5, 3, 1]]), jnp.array([[1.0, 0.0, 1.0]]))
+    players = RenderAgentInfo(
+        jnp.array([[8.5, 3, 1]]),
+        jnp.array([[0, -0.5, 1.0]]),
+        jnp.array([[1.0, 0.0, 1.0]]),
+    )
     props = RenderPropInfo(
         jnp.array([1]),
         jnp.array([[4, 3, 1]]),
@@ -71,6 +75,7 @@ def test_render_frame_with_objects() -> None:
         jnp.array([[[0, 1, 0] for _ in range(10)] for _ in range(10)]),
         players,
         props,
+        jnp.zeros((1, 6)),
         view_width=10,
         view_height=10,
     )

--- a/tests/test_sdfs.py
+++ b/tests/test_sdfs.py
@@ -150,3 +150,32 @@ def test_cube_sdf() -> None:
             atol=1e-05,
         )
     )
+
+
+def test_beam_sdf() -> None:
+    """Test the beam signed distance function."""
+    dists = []
+    view_dir = jnp.array([1, 1, 1]) / jnp.linalg.norm(jnp.array([1, 1, 1]))
+    for i in range(NUM_ITERS):
+        dists.append(float(beam_sdf(jnp.full((3,), i * 1.0), view_dir, 1)))
+
+    assert np.all(
+        np.isclose(
+            dists,
+            np.array(
+                [
+                    0.0,
+                    0.7320507764816284,
+                    2.464101791381836,
+                    4.196152210235596,
+                    5.928203105926514,
+                    7.660254001617432,
+                    9.392305374145508,
+                    11.124356269836426,
+                    12.856407165527344,
+                    14.588457107543945,
+                ]
+            ),
+            atol=1e-05,
+        )
+    )


### PR DESCRIPTION
Now each agent can see its tagging beam (in first person) as well as others' tagging beams (in third person)
Corresponding code modified in 
`__init__.py`: to allow the `render` function to take in agent actions
`renderer.py`: modified `__scene_sdf_from_objs` to include signed distance function of agent beams, `render_frame_with_objects` to take in agent actions, top-level `render` function
`sdfs.py`: added SDF of a beam using the signed distance field formula of a very thin cylinder.